### PR TITLE
expected state calcs take burn-on-commit into account

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracer-protocol/perpetual-pools-v2-pool-watcher",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "tracer perpetual pool watcher that can act as a building block for various types of bots",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -150,6 +150,8 @@ export type ExpectedPoolStateInputs = {
   shortBalance: BigNumber,
   longTokenSupply: BigNumber,
   shortTokenSupply: BigNumber,
+  pendingLongTokenBurn: BigNumber,
+  pendingShortTokenBurn: BigNumber,
   lastOraclePrice: BigNumber,
   currentOraclePrice: BigNumber,
   pendingCommits: Array<TotalPoolCommitmentsBN>

--- a/test/_mockData/index.ts
+++ b/test/_mockData/index.ts
@@ -35,8 +35,10 @@ export const expectedStateInputDefaults = {
   leverage: 3,
   longBalance: new BigNumber('120000000000000000000000'),
   shortBalance: new BigNumber('100000000000000000000000'),
-  longTokenSupply: new BigNumber('100000000000000000000000'),
-  shortTokenSupply: new BigNumber('100000000000000000000000'),
+  longTokenSupply: new BigNumber('90000000000000000000000'),
+  shortTokenSupply: new BigNumber('80000000000000000000000'),
+  pendingLongTokenBurn: new BigNumber('1000000000000000000000'),
+  pendingShortTokenBurn: new BigNumber('2000000000000000000000'),
   lastOraclePrice: new BigNumber('100000000000000000000000'),
   currentOraclePrice: new BigNumber('110000000000000000000000'),
   pendingCommits: [

--- a/test/poolWatcher/calculatePoolState.test.ts
+++ b/test/poolWatcher/calculatePoolState.test.ts
@@ -76,9 +76,13 @@ describe('PoolWatcher calculatePoolState', () => {
     } = poolWatcher.calculatePoolState(expectedStateInputDefaults);
 
     expect(currentLongBalance).toEqual(expectedStateInputDefaults.longBalance);
-    expect(currentLongSupply).toEqual(expectedStateInputDefaults.longTokenSupply);
+    expect(currentLongSupply).toEqual(
+      expectedStateInputDefaults.longTokenSupply.plus(expectedStateInputDefaults.pendingLongTokenBurn)
+    );
     expect(currentShortBalance).toEqual(expectedStateInputDefaults.shortBalance);
-    expect(currentShortSupply).toEqual(expectedStateInputDefaults.shortTokenSupply);
+    expect(currentShortSupply).toEqual(
+      expectedStateInputDefaults.shortTokenSupply.plus(expectedStateInputDefaults.pendingShortTokenBurn)
+    );
     expect(currentSkew).toEqual(currentLongBalance.div(currentShortBalance));
     expect(totalNetPendingLong).toEqual(new BigNumber(0));
     expect(totalNetPendingShort).toEqual(new BigNumber(0));
@@ -305,9 +309,13 @@ describe('PoolWatcher calculatePoolState', () => {
     const interval3FinalLongSupply = interval2FinalLongSupply.plus(interval3LongSupplyChange);
 
     expect(currentLongBalance).toEqual(calculateStateInputs.longBalance);
-    expect(currentLongSupply).toEqual(calculateStateInputs.longTokenSupply);
+    expect(currentLongSupply).toEqual(
+      calculateStateInputs.longTokenSupply.plus(calculateStateInputs.pendingLongTokenBurn)
+    );
     expect(currentShortBalance).toEqual(calculateStateInputs.shortBalance);
-    expect(currentShortSupply).toEqual(calculateStateInputs.shortTokenSupply);
+    expect(currentShortSupply).toEqual(
+      calculateStateInputs.shortTokenSupply.plus(calculateStateInputs.pendingShortTokenBurn)
+    );
     expect(currentSkew).toEqual(currentLongBalance.div(currentShortBalance));
 
     expect(expectedShortBalance).toEqual(interval3FinalShortBalance);
@@ -371,6 +379,9 @@ describe('PoolWatcher calculatePoolState', () => {
       shortBalance: interval1Result.expectedShortBalance,
       longTokenSupply: interval1Result.expectedLongSupply,
       shortTokenSupply: interval1Result.expectedShortSupply,
+      // these get added to starting balance so are already accounted for in interval 1
+      pendingLongTokenBurn: new BigNumber(0),
+      pendingShortTokenBurn: new BigNumber(0),
       lastOraclePrice: interval1Result.expectedOraclePrice,
       pendingCommits: [mockPendingCommits[1]]
     });
@@ -381,6 +392,9 @@ describe('PoolWatcher calculatePoolState', () => {
       shortBalance: interval2Result.expectedShortBalance,
       longTokenSupply: interval2Result.expectedLongSupply,
       shortTokenSupply: interval2Result.expectedShortSupply,
+      // these get added to starting balance so are already accounted for in interval 1
+      pendingLongTokenBurn: new BigNumber(0),
+      pendingShortTokenBurn: new BigNumber(0),
       lastOraclePrice: interval2Result.expectedOraclePrice,
       pendingCommits: [mockPendingCommits[2]]
     });
@@ -428,9 +442,13 @@ describe('PoolWatcher calculatePoolState', () => {
     } = poolWatcher.calculatePoolState(calculateStateInputs);
 
     expect(currentLongBalance).toEqual(expectedStateInputDefaults.longBalance);
-    expect(currentLongSupply).toEqual(expectedStateInputDefaults.longTokenSupply);
+    expect(currentLongSupply).toEqual(
+      expectedStateInputDefaults.longTokenSupply.plus(expectedStateInputDefaults.pendingLongTokenBurn)
+    );
     expect(currentShortBalance).toEqual(expectedStateInputDefaults.shortBalance);
-    expect(currentShortSupply).toEqual(expectedStateInputDefaults.shortTokenSupply);
+    expect(currentShortSupply).toEqual(
+      expectedStateInputDefaults.shortTokenSupply.plus(expectedStateInputDefaults.pendingShortTokenBurn)
+    );
     expect(currentSkew).toEqual(currentLongBalance.div(currentShortBalance));
     expect(totalNetPendingLong).toEqual(new BigNumber(0));
     expect(totalNetPendingShort).toEqual(new BigNumber(0));


### PR DESCRIPTION
update exepected state calcs to account for immediate token burns at time of commit