### PR TITLE
Use spot price for expected state calcs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracer-protocol/perpetual-pools-v2-pool-watcher",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "tracer perpetual pool watcher that can act as a building block for various types of bots",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@tracer-protocol/perpetual-pools-contracts": "^1.2.5",
-    "@tracer-protocol/pools-js": "^3.1.7",
+    "@tracer-protocol/pools-js": "^3.1.8",
     "ethers": "5.5.1",
     "tiny-typed-emitter": "^2.1.0"
   },

--- a/src/PoolWatcher.ts
+++ b/src/PoolWatcher.ts
@@ -196,7 +196,7 @@ export class PoolWatcher extends TypedEmitter<PoolWatcherEvents> {
       // oracle price is always stored in WAD format
       // the sdk formats from WAD
       // format it back so that it reflects raw on chain data
-      // which aligns with expected state calculations
+      // which aligns with last oracle price that we return from getPoolStatePreviewInputs
       return spotPrice.times(new BigNumber(10).pow(18));
     } catch (error) {
       // fall back to directly fetching from pool (will be wrong for SMA but correct for spot)

--- a/src/PoolWatcher.ts
+++ b/src/PoolWatcher.ts
@@ -5,7 +5,8 @@ import {
   pendingCommitsToBN,
   calcPoolStatePreview,
   PoolStatePreviewInputs,
-  ethersBNtoBN
+  ethersBNtoBN,
+  SMAOracle
 } from '@tracer-protocol/pools-js';
 
 // TODO: update to latest version after redeploy/abis are provided via sdk or other package
@@ -82,7 +83,8 @@ export class PoolWatcher extends TypedEmitter<PoolWatcherEvents> {
       settlementTokenAddress,
       longTokenAddress,
       shortTokenAddress,
-      lastPriceTimestamp
+      lastPriceTimestamp,
+      oracleWrapperAddress
     ] = await Promise.all([
       attemptPromiseRecursively({ promise: () => this.poolInstance.poolName() }),
       attemptPromiseRecursively({ promise: () => this.poolInstance.poolCommitter() }),
@@ -93,7 +95,8 @@ export class PoolWatcher extends TypedEmitter<PoolWatcherEvents> {
       attemptPromiseRecursively({ promise: () => this.poolInstance.settlementToken() }),
       attemptPromiseRecursively({ promise: () => this.poolInstance.tokens(0) }),
       attemptPromiseRecursively({ promise: () => this.poolInstance.tokens(1) }),
-      attemptPromiseRecursively({ promise: () => this.poolInstance.lastPriceTimestamp() })
+      attemptPromiseRecursively({ promise: () => this.poolInstance.lastPriceTimestamp() }),
+      attemptPromiseRecursively({ promise: () => this.poolInstance.oracleWrapper() })
     ]);
 
     const leverage = await attemptPromiseRecursively({
@@ -104,9 +107,15 @@ export class PoolWatcher extends TypedEmitter<PoolWatcherEvents> {
       promise: () => settlementTokenInstance.decimals()
     });
 
+    const smaOracle = await SMAOracle.Create({
+      address: oracleWrapperAddress,
+      provider: this.provider
+    });
+
     this.watchedPool = {
       address: this.poolAddress,
       committerInstance: PoolCommitter__factory.connect(committerAddress, this.provider),
+      smaOracle,
       name,
       keeperInstance: PoolKeeper__factory.connect(keeperAddress, this.provider),
       updateInterval,
@@ -179,6 +188,24 @@ export class PoolWatcher extends TypedEmitter<PoolWatcherEvents> {
     return appropriateUpdateIntervalId.eq(updateIntervalId);
   }
 
+  async getOracleSpotPrice (): Promise<BigNumber> {
+    // assume that oracle is SMA
+    try {
+      const spotPrice = await this.watchedPool.smaOracle.getSpotPrice();
+
+      // oracle price is always stored in WAD format
+      // the sdk formats from WAD
+      // format it back so that it reflects raw on chain data
+      // which aligns with expected state calculations
+      return spotPrice.times(new BigNumber(10).pow(18));
+    } catch (error) {
+      // fall back to directly fetching from pool (will be wrong for SMA but correct for spot)
+      const currentOraclePriceFromPool = await this.poolInstance.getOraclePrice();
+
+      return ethersBNtoBN(currentOraclePriceFromPool);
+    }
+  }
+
   async getPoolStatePreviewInputs (): Promise<PoolStatePreviewInputs> {
     if (!this.watchedPool.address) {
       throw new Error('getExpectedStateInput: watched pool not initialised');
@@ -200,7 +227,7 @@ export class PoolWatcher extends TypedEmitter<PoolWatcherEvents> {
     ] = await Promise.all([
       attemptPromiseRecursively({ promise: () => this.poolInstance.longBalance() }),
       attemptPromiseRecursively({ promise: () => this.poolInstance.shortBalance() }),
-      attemptPromiseRecursively({ promise: () => this.poolInstance.getOraclePrice() }),
+      attemptPromiseRecursively({ promise: () => this.getOracleSpotPrice() }),
       attemptPromiseRecursively({ promise: () => keeperInstance.executionPrice(this.poolAddress) }),
       attemptPromiseRecursively({ promise: () => this.getRelevantPendingCommits() }),
       attemptPromiseRecursively({ promise: () => longTokenInstance.totalSupply() }),
@@ -215,7 +242,7 @@ export class PoolWatcher extends TypedEmitter<PoolWatcherEvents> {
       longBalance: ethersBNtoBN(longBalance),
       shortBalance: ethersBNtoBN(shortBalance),
       lastOraclePrice: ethersBNtoBN(lastOraclePrice),
-      currentOraclePrice: ethersBNtoBN(currentOraclePrice),
+      currentOraclePrice,
       pendingCommits,
       longTokenSupply: ethersBNtoBN(longTokenSupply),
       shortTokenSupply: ethersBNtoBN(shortTokenSupply),

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ import {
 } from '@tracer-protocol/perpetual-pools-contracts/types';
 
 import { EVENT_NAMES } from './constants';
+import { SMAOracle } from '@tracer-protocol/pools-js';
 
 export type RawCommitType = 0 | 1 | 2 | 3 | 4 | 5
 
@@ -69,6 +70,7 @@ export type WatchedPool = {
   name: string,
   settlementTokenDecimals: number,
   keeperInstance: PoolKeeper,
+  smaOracle: SMAOracle,
   updateInterval: number,
   lastPriceTimestamp: number,
   leverage: number,

--- a/test/_mockData/index.ts
+++ b/test/_mockData/index.ts
@@ -88,6 +88,7 @@ export const getInitializedMockPoolWatcher = async ({
   mockPoolSwapLibraryFactory,
   mockPoolCommitterFactory,
   mockERC20Factory,
+  mockSMAOracle,
   _mockPoolData
 }: {
   constructorArgs: PoolWatcherConstructorArgs,
@@ -95,11 +96,13 @@ export const getInitializedMockPoolWatcher = async ({
   mockPoolSwapLibraryFactory: any,
   mockPoolCommitterFactory: any,
   mockERC20Factory: any,
+  mockSMAOracle: any,
   _mockPoolData?: Partial<typeof mockPoolData>,
 }): Promise<PoolWatcher> => {
   const mockPoolInstance = {
     poolName: async () => _mockPoolData?.poolName || mockPoolData.poolName,
     keeper: async () => _mockPoolData?.keeper || mockPoolData.keeper,
+    oracleWrapper: async () => _mockPoolData?.oracleWrapper || mockPoolData.oracleWrapper,
     poolCommitter: async () => _mockPoolData?.poolCommitter || mockPoolData.poolCommitter,
     updateInterval: async () => _mockPoolData?.updateInterval || mockPoolData.updateInterval,
     leverageAmount: async () => _mockPoolData?.leverageAmount || mockPoolData.leverageAmount,
@@ -139,6 +142,7 @@ export const getInitializedMockPoolWatcher = async ({
   mockPoolSwapLibraryFactory.connect.mockReturnValueOnce(mockPoolSwapLibraryInstance);
   mockPoolCommitterFactory.connect.mockReturnValueOnce(mockPoolCommitterInstance);
   mockERC20Factory.connect.mockReturnValueOnce(mockSettlementTokenInstance);
+  mockSMAOracle.Create.mockReturnValueOnce({});
 
   const poolWatcher = new PoolWatcher(constructorArgs);
 

--- a/test/poolWatcher/getRelevantPendingCommits.test.ts
+++ b/test/poolWatcher/getRelevantPendingCommits.test.ts
@@ -15,6 +15,10 @@ import {
 } from '@tracer-protocol/perpetual-pools-contracts/types';
 
 import {
+  SMAOracle
+} from '@tracer-protocol/pools-js';
+
+import {
   constructorDefaults,
   getInitializedMockPoolWatcher
 } from '../_mockData';
@@ -23,11 +27,13 @@ import { PoolWatcherConstructorArgs } from '../../src/types';
 
 jest.mock('ethers');
 jest.mock('@tracer-protocol/perpetual-pools-contracts/types'); ;
+jest.mock('@tracer-protocol/pools-js'); ;
 
 const mockLeveragedPoolFactory = jest.mocked(LeveragedPool__factory, true);
 const mockPoolSwapLibraryFactory = jest.mocked(PoolSwapLibrary__factory, true);
 const mockPoolCommitterFactory = jest.mocked(PoolCommitter__factory, true);
 const mockERC20Factory = jest.mocked(ERC20__factory, true);
+const mockSMAOracle = jest.mocked(SMAOracle, true);
 
 const spotOracleTransformer: PoolWatcherConstructorArgs['oraclePriceTransformer'] = (lastPrice, newPrice) => newPrice;
 
@@ -46,7 +52,8 @@ describe('PoolWatcher getRelevantPendingCommits', () => {
       mockLeveragedPoolFactory,
       mockPoolSwapLibraryFactory,
       mockPoolCommitterFactory,
-      mockERC20Factory
+      mockERC20Factory,
+      mockSMAOracle
     });
 
     const getPendingCommitsSpy = jest.spyOn(poolWatcher.watchedPool.committerInstance, 'totalPoolCommitments');
@@ -68,7 +75,8 @@ describe('PoolWatcher getRelevantPendingCommits', () => {
       mockLeveragedPoolFactory,
       mockPoolSwapLibraryFactory,
       mockPoolCommitterFactory,
-      mockERC20Factory
+      mockERC20Factory,
+      mockSMAOracle
     });
 
     const totalPoolCommitmentsSpy = jest.spyOn(poolWatcher.watchedPool.committerInstance, 'totalPoolCommitments');
@@ -97,7 +105,8 @@ describe('PoolWatcher getRelevantPendingCommits', () => {
       mockLeveragedPoolFactory,
       mockPoolSwapLibraryFactory,
       mockPoolCommitterFactory,
-      mockERC20Factory
+      mockERC20Factory,
+      mockSMAOracle
     });
 
     const totalPoolCommitmentsSpy = jest.spyOn(poolWatcher.watchedPool.committerInstance, 'totalPoolCommitments');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2154,10 +2154,10 @@
   resolved "https://registry.npmjs.org/@tracer-protocol/perpetual-pools-contracts/-/perpetual-pools-contracts-1.2.5.tgz#1c579c0bfeed93791ace37ae22add118b1fc24c5"
   integrity sha512-cgE80mAr3m/khjjoU1eojhs4ZN3Miu+Gl03/zRy4mKc3dpDAVryVf1726PC9fZ1DES9uVA6/htrXH5UbuEppdQ==
 
-"@tracer-protocol/pools-js@^3.1.7":
-  version "3.1.7"
-  resolved "https://registry.npmjs.org/@tracer-protocol/pools-js/-/pools-js-3.1.7.tgz#cef9ae3b849e0445bb684ae5dfa2770581d98359"
-  integrity sha512-iqz3O1cVAAbr6ZM4Uw8zLwuTbsAzpChVPU9u9/C2+NvNml7Wc0rrzWc/gtzmsgj/m9RBL1M+cbuyHYTPFA1wxg==
+"@tracer-protocol/pools-js@^3.1.8":
+  version "3.1.8"
+  resolved "https://registry.npmjs.org/@tracer-protocol/pools-js/-/pools-js-3.1.8.tgz#3f758e65f6501620c9afe3c01f35ab23fa0c6d68"
+  integrity sha512-nm8SivdG7epAp2O2x4pka3RAtIPngVHa96vqC33J5Fl96+Js459f6iLWXx7F32pNStkkBvNxQLI1PwgII+NBfA==
   dependencies:
     "@tracer-protocol/perpetual-pools-contracts" "^1.2.5"
     bignumber.js "^9.0.1"


### PR DESCRIPTION
- store instance of sdk `SMAOracle` in `PoolWatcher`
- use `SMAOracle.getSpotPrice` when getting `nextOraclePrice` for expected state calculations 